### PR TITLE
Use startOrReload with pm2 for graceful deployments

### DIFF
--- a/lib/capistrano/tasks/pm2.rake
+++ b/lib/capistrano/tasks/pm2.rake
@@ -5,7 +5,7 @@ namespace :pm2 do
   task :start_or_graceful_reload do
     on roles fetch(:pm2_roles) do
       app_names.each do |app_name|
-        run_task :pm2, :startOrGracefulReload, fetch(:pm2_app_command), "--name #{app_name} #{fetch(:pm2_start_params)}"
+        run_task :pm2, :startOrReload, fetch(:pm2_app_command)
       end
     end
   end


### PR DESCRIPTION
In my testing of pm2, I've found that `startOrGracefulReload` does not do graceful reloading even with the proper processing of start and shutdown signals sent by PM2. However the `startOrReload` command does indeed do what we want and can achieve a zero second downtime deployment as noted here: http://pm2.keymetrics.io/docs/usage/signals-clean-restart/#graceful-stop

I also removed the additional parameters from the end of the pm2 command since we should be putting any parameters into our `process.json` files

